### PR TITLE
Fix: Resolve audio playback issues after pause/resume

### DIFF
--- a/src/components/AudioRecorder.tsx
+++ b/src/components/AudioRecorder.tsx
@@ -58,14 +58,6 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({ onDownload, onDelete }) =
   // Calculate display time for timer
   const getDisplayTime = () => {
     if (isPlaying) {
-      // During playback, scale the audio playback time to match the total recording duration
-      // This ensures the timer shows the correct time relative to the original recording
-      if (audioBlob) {
-        // We need to create a temporary audio element to get the actual audio duration
-        // But for now, we'll use a simple scaling approach
-        const totalDuration = totalRecordingDuration || duration;
-        return Math.floor((playbackTime / (audioBlob.size / 100000)) * totalDuration);
-      }
       return Math.floor(playbackTime);
     }
     return duration;

--- a/src/components/AudioWaveform.tsx
+++ b/src/components/AudioWaveform.tsx
@@ -97,10 +97,7 @@ const AudioWaveform: React.FC<AudioWaveformProps> = ({
     // Calculate progress based on the relationship between actual audio time and total recording time
     let progress = 0;
     if (isPlaying && actualAudioDuration > 0) {
-      // Scale the audio playback time to match the total recording duration
-      // This accounts for the fact that paused recordings create compressed audio
-      const scaledPlaybackTime = (playbackTime / actualAudioDuration) * totalRecordingDuration;
-      progress = Math.min(Math.max(scaledPlaybackTime / totalRecordingDuration, 0), 1);
+      progress = Math.min(Math.max(playbackTime / actualAudioDuration, 0), 1);
     }
 
     // Clear canvas


### PR DESCRIPTION
Addresses two visual bugs that occurred during playback of audio recorded with a pause/resume cycle:

1.  **Waveform Visualization:** The waveform did not correctly display or highlight the played portion for audio recorded after resuming. This was fixed by:
    - Ensuring `totalRecordingDuration` in `useAudioRecorder.ts` is accurately calculated by decoding the final audio blob to get its true duration.
    - Modifying `AudioWaveform.tsx` to use its internally derived `actualAudioDuration` (from the audio blob) and `playbackTime` (from the audio element) for its progress calculation, making it robust and independent of potentially inaccurate props.

2.  **Playback Timer:** The timer did not count up correctly for audio recorded after resuming. This was fixed by:
    - Simplifying the `getDisplayTime()` function in `AudioRecorder.tsx` to directly use `playbackTime` (which reflects `audioElement.currentTime`) when audio is playing. This removes previous complex and error-prone scaling logic.

These changes ensure that both the waveform visualization and the playback timer accurately reflect the state of the audio throughout its entire duration, even when the recording involves pause and resume operations.